### PR TITLE
Remove acquire_credentials and use delegation to forward tickets.

### DIFF
--- a/lib/net/ssh/authentication/methods/gssapi_with_mic.rb
+++ b/lib/net/ssh/authentication/methods/gssapi_with_mic.rb
@@ -45,7 +45,8 @@ module Net
               established = false
 			      debug { "gssapi-with-mic handshaking" }
 	          until established
-	            token = gss.init_context(token)
+	            # :delegate => true always forwards tickets.  This may or may not be a good idea, and should really be a user-specified option.
+	            token = gss.init_context(token, :delegate => true)
 	            break if token === true
 	            if token && token.length > 0
 					      send_message Net::SSH::Buffer.from(:byte, USERAUTH_GSSAPI_TOKEN, :string, token)


### PR DESCRIPTION
Here are the changes that I mentioned elsewhere.

The first one removes the acquire_credentials call, which sometimes fails and should never be needed anyway.

The second turns on delegation in init_context, which has both pros and cons.  See the commit message for more details.
