### PR TITLE
Bump GSSAPI gem version to 1.3.0

### DIFF
--- a/net-ssh-kerberos.gemspec
+++ b/net-ssh-kerberos.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.summary = %q{Add Kerberos support to Net::SSH}
 
   s.add_dependency 'net-ssh', '>= 2.0'
-  s.add_dependency 'gssapi', '~> 1.2.0'
+  s.add_dependency 'gssapi', '~> 1.3.0'
   
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', "~> 3.0"


### PR DESCRIPTION
Many modern ruby gems use the latest GSSAPI gem, which is 1.3.0. I
tested this locally, and it doesn't seem to impact behavior of
net-ssh-krb as the release is mostly additive and doesn't include
breaking changes.